### PR TITLE
Regional RubyKaigi のリンク修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
 <div style='background: #000'>
   <div style='width: 90%; margin: 0 auto'>
-    <a href="/" class="regional_rubykaigi">Regional RubyKaigi</a>
+    <a href="https://regional.rubykaigi.org/" class="regional_rubykaigi">Regional RubyKaigi</a>
   </div>
 </div>
 <div id='wrapper'>


### PR DESCRIPTION
ページヘッダの "Regional RubyKaigi" は https://regional.rubykaigi.org/ にリンクするのが正しそうなのでそうした。

変更前は以下のように転送設定されたregionalからくるか github.ioからくるかで遷移先が異なっていた。 "Regional RubyKaigi" に固定的にリンクするのが正しそうなので、絶対URLで指定してどちらでも正しいリンク先に飛ぶようにした。

- https://tokyurubykaigi.github.io/tokyu13/ → https://tokyurubykaigi.github.io/  (facebook の tokyu.rb グループに転送
- http://regional.rubykaigi.org/tokyu13/ → https://regional.rubykaigi.org/
  - このURLは今はまだ無い。今後設定予定。